### PR TITLE
Composer minimum-stability, rc -> RC

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "optimize-autoloader": true
     },
     "prefer-stable": true,
-    "minimum-stability": "rc",
+    "minimum-stability": "RC",
     "scripts": {
       "pre-install-cmd": [
         "[ ! -f vendor/autoload.php ] || bin/console system:update:prepare"


### PR DESCRIPTION
Composer require anything doesn't work with "rc". Should be uppercase, see https://getcomposer.org/doc/04-schema.md#minimum-stability