### PR TITLE
refine documentation about to use wildcards

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,6 @@ You only need to require the things you want. If you only want to run shopware 6
 
 Run the following command, to update all shopware dependencies:
 ```bash
-composer update shopware/*
+composer update "shopware/*"
 ```
 


### PR DESCRIPTION
If you try to run composer update shopware/* without slashes you get an error. [Documentation](https://getcomposer.org/doc/03-cli.md#update-u) says use with slashes. 