### PR TITLE
Allow composer install --no-dev

### DIFF
--- a/config/bundles.php
+++ b/config/bundles.php
@@ -29,4 +29,4 @@ if (class_exists('Symfony\\Bundle\\DebugBundle\\DebugBundle')) {
     $bundles[Symfony\Bundle\DebugBundle\DebugBundle::class] = ['dev' => true, 'test' => true];
 }
 
-return $bundle;
+return $bundles;

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -1,21 +1,32 @@
 <?php declare(strict_types=1);
 
-return [
+$bundles = [
     Symfony\Bundle\FrameworkBundle\FrameworkBundle::class => ['all' => true],
     Symfony\Bundle\MonologBundle\MonologBundle::class => ['all' => true],
     Symfony\Bundle\SwiftmailerBundle\SwiftmailerBundle::class => ['all' => true],
     Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle::class => ['all' => true],
     Symfony\Bundle\TwigBundle\TwigBundle::class => ['all' => true],
-    Symfony\Bundle\WebProfilerBundle\WebProfilerBundle::class => ['dev' => true, 'test' => true],
-    Symfony\Bundle\DebugBundle\DebugBundle::class => ['dev' => true, 'test' => true],
     Enqueue\Bundle\EnqueueBundle::class => ['all' => true],
     Enqueue\MessengerAdapter\Bundle\EnqueueAdapterBundle::class => ['all' => true],
     Shopware\Core\Framework\Framework::class => ['all' => true],
     Shopware\Core\System\System::class => ['all' => true],
     Shopware\Core\Content\Content::class => ['all' => true],
     Shopware\Core\Checkout\Checkout::class => ['all' => true],
-    Shopware\Core\Profiling\Profiling::class => ['dev' => true],
     Shopware\Administration\Administration::class => ['all' => true],
     Shopware\Storefront\Storefront::class => ['all' => true],
     Shopware\Elasticsearch\Elasticsearch::class => ['all' => true],
 ];
+
+if (class_exists('Symfony\\Bundle\\WebProfilerBundle\\WebProfilerBundle')) {
+    $bundles[Symfony\Bundle\WebProfilerBundle\WebProfilerBundle::class] = ['dev' => true, 'test' => true];
+
+    if (class_exists('Shopware\\Core\\Profiling\\Profiling')) {
+        $bundles[Shopware\Core\Profiling\Profiling::class] = ['dev' => true];
+    }
+}
+
+if (class_exists('Symfony\\Bundle\\DebugBundle\\DebugBundle')) {
+    $bundles[Symfony\Bundle\DebugBundle\DebugBundle::class] = ['dev' => true, 'test' => true];
+}
+
+return $bundle;


### PR DESCRIPTION
I reconfigured bundles to only be loaded when their class exists. Some of the classes don't exist on a `composer install --no-dev` and therefore break the installation.

BTW Why would you ever run a production system without `--no-dev`?