### PR TITLE
Ignore generated bundle output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ custom/*
 !/public/thumbnail/.gitkeep
 /public/plugins/*
 /public/assets/*
+/public/bundles/*
 
 /files/*
 


### PR DESCRIPTION
Executing any build command results in a filled public/bundles folder. This should not be versioned