### PR TITLE
Require more steps for building storefront

### DIFF
--- a/bin/build-storefront.sh
+++ b/bin/build-storefront.sh
@@ -6,6 +6,8 @@ export PROJECT_ROOT="${PROJECT_ROOT:-"$(dirname $CWD)"}"
 STOREFRONT_ROOT="${STOREFRONT_ROOT:-"${PROJECT_ROOT}/vendor/shopware/storefront"}"
 
 # build storefront
+"${CWD}/console" bundle:dump
 npm --prefix ${STOREFRONT_ROOT}/Resources/app/storefront clean-install
 node ${STOREFRONT_ROOT}/Resources/app/storefront/copy-to-vendor.js
 npm --prefix ${STOREFRONT_ROOT}/Resources/app/storefront run production
+"${CWD}/console" asset:install


### PR DESCRIPTION
The scripts does not work out of the box. You still have to dump the bundle configurations (e.g. changes in theme.json or new plugins) and publish the generated assets.