### PR TITLE
Run same command multiple times in install

### DIFF
--- a/config/services/defaults.xml
+++ b/config/services/defaults.xml
@@ -23,6 +23,7 @@
     <services>
         <service id="Shopware\Production\Command\SystemInstallCommand">
             <argument type="string">%kernel.project_dir%</argument>
+            <argument type="string">%kernel.cache_dir%</argument>
             <tag name="console.command"/>
         </service>
 

--- a/src/Command/SystemInstallCommand.php
+++ b/src/Command/SystemInstallCommand.php
@@ -9,6 +9,7 @@ use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\FetchMode;
 use Shopware\Core\Framework\Adapter\Console\ShopwareStyle;
 use Shopware\Production\Kernel;
+use Symfony\Bundle\FrameworkBundle\Command\CacheClearCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
@@ -30,10 +31,16 @@ class SystemInstallCommand extends Command
      */
     protected $io;
 
-    public function __construct(string $projectDir)
+    /**
+     * @var string
+     */
+    private $cacheDir;
+
+    public function __construct(string $projectDir, string $cacheDir)
     {
         parent::__construct();
         $this->projectDir = $projectDir;
+        $this->cacheDir = $cacheDir;
     }
 
     protected function configure(): void
@@ -185,6 +192,11 @@ class SystemInstallCommand extends Command
             $returnCode = $command->run(new ArrayInput($parameters, $command->getDefinition()), $output);
             if ($returnCode !== 0) {
                 return $returnCode;
+            }
+
+            // recreate cache dir after clearing cache
+            if (($command instanceof CacheClearCommand) && !is_dir($this->cacheDir)) {
+                @mkdir($this->cacheDir, 0777, true);
             }
         }
 

--- a/src/Command/SystemInstallCommand.php
+++ b/src/Command/SystemInstallCommand.php
@@ -169,11 +169,19 @@ class SystemInstallCommand extends Command
      */
     private function runCommands(array $commands, OutputInterface $output): int
     {
-        foreach($commands as $parameters) {
+        $executedCommands = [];
+
+        foreach ($commands as $parameters) {
             $output->writeln('');
 
             $command = $this->getApplication()->find($parameters['command']);
-            unset($parameters['command']);
+
+            // keep command parameter as it is needed when a command is executed twice
+            if (!in_array($command->getName(), $executedCommands)) {
+                $executedCommands[] = $command->getName();
+                unset($parameters['command']);
+            }
+
             $returnCode = $command->run(new ArrayInput($parameters, $command->getDefinition()), $output);
             if ($returnCode !== 0) {
                 return $returnCode;


### PR DESCRIPTION
When you queue up a command twice into the SystemInstallCommand you run into the following error:

```
In Input.php line 76:
                                                          
  [Symfony\Component\Console\Exception\RuntimeException]  
  Not enough arguments (missing: "command").                                                          

Exception trace:
  at vendor/symfony/console/Input/Input.php:76
 Symfony\Component\Console\Input\Input->validate() at vendor/symfony/console/Input/Input.php:42
 Symfony\Component\Console\Input\Input->__construct() at vendor/symfony/console/Input/ArrayInput.php:34
 Symfony\Component\Console\Input\ArrayInput->__construct() at src/Command/SystemInstallCommand.php:190
 Shopware\Production\Command\SystemInstallCommand->runCommands() at src/Command/SystemInstallCommand.php:173
 Shopware\Production\Command\SystemInstallCommand->execute() at vendor/symfony/console/Command/Command.php:255
 Symfony\Component\Console\Command\Command->run() at vendor/symfony/console/Application.php:1029
 Symfony\Component\Console\Application->doRunCommand() at vendor/symfony/framework-bundle/Console/Application.php:97
 Symfony\Bundle\FrameworkBundle\Console\Application->doRunCommand() at vendor/symfony/console/Application.php:272
 Symfony\Component\Console\Application->doRun() at vendor/symfony/framework-bundle/Console/Application.php:83
 Symfony\Bundle\FrameworkBundle\Console\Application->doRun() at vendor/symfony/console/Application.php:148
 Symfony\Component\Console\Application->run() at bin/console:68
```

That is super easy to explain why this happens:
https://github.com/symfony/symfony/blob/f64f59a9c0d92fdd65f9de3e44b612402b224aaf/src/Symfony/Component/Console/Command/Command.php#L312
Later explained:
https://github.com/symfony/symfony/blob/f64f59a9c0d92fdd65f9de3e44b612402b224aaf/src/Symfony/Component/Console/Command/Command.php#L243-L248

This sucks.

How to reproduce?
```php
$this->runCommands([
    ['command' => 'plugin:list'],
    ['command' => 'plugin:list'],
], $output);
```

Fun fact for part two.

When you clean up the cache twice:
```php
$this->runCommands([
    ['command' => 'cache:clear'],
    ['command' => 'cache:clear'],
], $output);
```
The cache directory is not just empty but also removed. Unfortunately symfony expects it to exist to clear it up:

```
In CacheClearCommand.php line 88:
                                                                                                                                        
  [Symfony\Component\Console\Exception\RuntimeException]                                                                                
  Unable to write in the "var/cache/dev_hfe2a414dcefb31c944f1ecea90f14af_" directory  
                                                                                                                                        

Exception trace:
  at vendor/symfony/framework-bundle/Command/CacheClearCommand.php:88
 Symfony\Bundle\FrameworkBundle\Command\CacheClearCommand->execute() at vendor/symfony/console/Command/Command.php:255
 Symfony\Component\Console\Command\Command->run() at src/Command/SystemInstallCommand.php:204
 Shopware\Production\Command\SystemInstallCommand->runCommands() at src/Command/SystemInstallCommand.php:180
 Shopware\Production\Command\SystemInstallCommand->execute() at vendor/symfony/console/Command/Command.php:255
 Symfony\Component\Console\Command\Command->run() at vendor/symfony/console/Application.php:1029
 Symfony\Component\Console\Application->doRunCommand() at vendor/symfony/framework-bundle/Console/Application.php:97
 Symfony\Bundle\FrameworkBundle\Console\Application->doRunCommand() at vendor/symfony/console/Application.php:272
 Symfony\Component\Console\Application->doRun() at vendor/symfony/framework-bundle/Console/Application.php:83
 Symfony\Bundle\FrameworkBundle\Console\Application->doRun() at vendor/symfony/console/Application.php:148
 Symfony\Component\Console\Application->run() at bin/console:68
```

https://github.com/symfony/symfony/blob/98c4f6a06ce6b04e17b72329522868d9646ce3dd/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php#L87-L90

That is the reason why we at least have to create it again.