### PR TITLE
Fix OAuth2 error on Windows regarding pem file permissions

### DIFF
--- a/config/services/defaults.xml
+++ b/config/services/defaults.xml
@@ -43,10 +43,13 @@
         <service class="League\OAuth2\Server\CryptKey" id="shopware.private_key">
             <argument>%kernel.project_dir%/config/jwt/private.pem</argument>
             <argument>%env(string:default:jwt_private_key_passphrase_default:JWT_PRIVATE_KEY_PASSPHRASE)%</argument>
+            <argument key="$keyPermissionsCheck">false</argument>
         </service>
 
         <service class="League\OAuth2\Server\CryptKey" id="shopware.public_key">
             <argument>%kernel.project_dir%/config/jwt/public.pem</argument>
+            <argument></argument>
+            <argument key="$keyPermissionsCheck">false</argument>
         </service>
 
         <service id="_dummy_env_usage" class="iterable" lazy="true">


### PR DESCRIPTION
When in dev mode on a windows computer, the following error is generated when creating an instance of CrpytKey:

```User Notice: Key file public.pem permissions are not correct, recommend changing to 600 or 660 instead of 666```

However, Windows permissions don't work in the same way and don't really allow for 600 or 660.

The 3rd argument to CryptKey constructor skips this permissions check.

It should perhaps be disabled in dev, and enabled in production, but I'm not sure how to do that as yet.