### PR TITLE
Remove --no-cleanup from asset-install in update:finish command

### DIFF
--- a/src/Command/SystemUpdateFinishCommand.php
+++ b/src/Command/SystemUpdateFinishCommand.php
@@ -21,7 +21,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class SystemUpdateFinishCommand extends Command
 {
-    static public $defaultName = 'system:update:finish';
+    public static $defaultName = 'system:update:finish';
 
     /**
      * @var SymfonyStyle
@@ -44,7 +44,7 @@ class SystemUpdateFinishCommand extends Command
         $output = new ShopwareStyle($input, $output);
 
         $dsn = trim((string)($_SERVER['DATABASE_URL'] ?? getenv('DATABASE_URL')));
-        if ($dsn === '' || $dsn === Kernel::PLACEHOLDER_DATABASE_URL)  {
+        if ($dsn === '' || $dsn === Kernel::PLACEHOLDER_DATABASE_URL) {
             $output->note("Environment variable 'DATABASE_URL' not defined. Skipping " . $this->getName() . '...');
             return 0;
         }
@@ -89,7 +89,7 @@ class SystemUpdateFinishCommand extends Command
     private function installAssets(InputInterface $input, OutputInterface $output): int
     {
         $command = $this->getApplication()->find('assets:install');
-        return $command->run(new ArrayInput(['--no-cleanup' => true], $command->getDefinition()), $output);
+        return $command->run(new ArrayInput([], $command->getDefinition()), $output);
     }
 
     private function rebootKernelWithoutPlugins(): ContainerInterface


### PR DESCRIPTION
The `--no-cleanup` option was removed, therefore the `system:asset:finish`-command fails with:

```
$ php bin/console system:update:finish
Run Post Update

Get collection from directories
migrate Migrations
    0 [=░░░░░░░░░░░░░░░░░░░░░░░░░░░]

 ---------- ---------------------- 
  Action     Number of migrations  
 ---------- ---------------------- 
  Migrated   0 out of 0            
 ---------- ---------------------- 

all migrations executed
cleared the shopware cache
09:35:22 ERROR     [console] Error thrown while running command "system:update:finish". Message: "The "--no-cleanup" option does not exist." ["exception" => Symfony\Component\Console\Exception\InvalidOptionException^ { …},"command" => "system:update:finish","message" => "The "--no-cleanup" option does not exist."]

                                             
  The "--no-cleanup" option does not exist.  
                                             

system:update:finish [-h|--help] [-q|--quiet] [-v|vv|vvv|--verbose] [-V|--version] [--ansi] [--no-ansi] [-n|--no-interaction] [-e|--env ENV] [--no-debug] [--] <command>
```