### PR TITLE
Fixing docker-compose build error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN apk --no-cache add \
     mkdir -p /var/cache/composer
 
 # Install composer
-COPY --from=composer /usr/bin/composer /usr/bin/composer
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 
 # Copy system configs
 COPY config/etc /etc

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,8 @@ RUN apk --no-cache add \
         gnu-libiconv \
     && adduser -u 1000 -D -h $PROJECT_ROOT sw6 sw6 \
     && rm /etc/nginx/conf.d/default.conf
-    
-# Install compose 
+
+# Install compose
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer
 
 # Copy system configs
@@ -36,7 +36,8 @@ USER sw6
 
 ADD --chown=sw6 . .
 
-RUN APP_URL="http://localhost" DATABASE_URL="" bin/console assets:install \
+RUN composer install && \
+    APP_URL="http://localhost" DATABASE_URL="" bin/console assets:install \
     && rm -Rf var/cache \
     && touch install.lock \
     && mkdir -p var/cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,9 @@ RUN apk --no-cache add \
         gnu-libiconv \
     && adduser -u 1000 -D -h $PROJECT_ROOT sw6 sw6 \
     && rm /etc/nginx/conf.d/default.conf
+    
+# Install compose 
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer
 
 # Copy system configs
 COPY config/etc /etc
@@ -24,7 +27,8 @@ COPY config/etc /etc
 RUN chown -R sw6.sw6 /run && \
   chown -R sw6.sw6 /var/lib/nginx && \
   chown -R sw6.sw6 /var/tmp/nginx && \
-  chown -R sw6.sw6 /var/log/nginx
+  chown -R sw6.sw6 /var/log/nginx && \
+  chown -R sw6.sw6 /var/cache/composer
 
 WORKDIR $PROJECT_ROOT
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,10 +15,11 @@ RUN apk --no-cache add \
         php7-zip php7-zlib php7-phar git \
         gnu-libiconv \
     && adduser -u 1000 -D -h $PROJECT_ROOT sw6 sw6 \
-    && rm /etc/nginx/conf.d/default.conf
+    && rm /etc/nginx/conf.d/default.conf && \
+    mkdir -p /var/cache/composer
 
-# Install compose
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer
+# Install composer
+COPY --from=composer /usr/bin/composer /usr/bin/composer
 
 # Copy system configs
 COPY config/etc /etc


### PR DESCRIPTION
- `bin/console assets:install` can only be run if compose is available 
- installing compose and fixing the permissions for /var/cache/composer