### PR TITLE
escape the source variable, so that directories with spaces can be used

### DIFF
--- a/bin/build-administration.sh
+++ b/bin/build-administration.sh
@@ -4,11 +4,11 @@ CWD="$(cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 
 set -e
 
-export PROJECT_ROOT="${PROJECT_ROOT:-"$(dirname $CWD)"}"
+export PROJECT_ROOT="${PROJECT_ROOT:-"$(dirname "$CWD")"}"
 ADMIN_ROOT="${ADMIN_ROOT:-"${PROJECT_ROOT}/vendor/shopware/administration"}"
 
 # build admin
 [[ ${CI} ]] || "${CWD}/console" bundle:dump
-npm clean-install --prefix ${ADMIN_ROOT}/Resources/app/administration
-npm run --prefix ${ADMIN_ROOT}/Resources/app/administration/ build
+npm clean-install --prefix "${ADMIN_ROOT}"/Resources/app/administration
+npm run --prefix "${ADMIN_ROOT}"/Resources/app/administration/ build
 [[ ${CI} ]] || "${CWD}/console" asset:install

--- a/bin/build-storefront.sh
+++ b/bin/build-storefront.sh
@@ -2,12 +2,12 @@
 
 CWD="$(cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 
-export PROJECT_ROOT="${PROJECT_ROOT:-"$(dirname $CWD)"}"
+export PROJECT_ROOT="${PROJECT_ROOT:-"$(dirname "$CWD")"}"
 STOREFRONT_ROOT="${STOREFRONT_ROOT:-"${PROJECT_ROOT}/vendor/shopware/storefront"}"
 
 # build storefront
 [[ ${CI} ]] || "${CWD}/console" bundle:dump
-npm --prefix ${STOREFRONT_ROOT}/Resources/app/storefront clean-install
-node ${STOREFRONT_ROOT}/Resources/app/storefront/copy-to-vendor.js
-npm --prefix ${STOREFRONT_ROOT}/Resources/app/storefront run production
+npm --prefix "${STOREFRONT_ROOT}"/Resources/app/storefront clean-install
+node "${STOREFRONT_ROOT}"/Resources/app/storefront/copy-to-vendor.js
+npm --prefix "${STOREFRONT_ROOT}"/Resources/app/storefront run production
 [[ ${CI} ]] || "${CWD}/console" asset:install

--- a/bin/watch-administration.sh
+++ b/bin/watch-administration.sh
@@ -5,7 +5,7 @@ CWD="$(cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 export PROJECT_ROOT="${PROJECT_ROOT:-"$(dirname $CWD)"}"
 export ENV_FILE=${ENV_FILE:-"${PROJECT_ROOT}/.env"}
 
-source ${ENV_FILE}
+source "${ENV_FILE}"
 export HOST=${HOST:-"localhost"}
 export ESLINT_DISABLE
 export PORT

--- a/bin/watch-administration.sh
+++ b/bin/watch-administration.sh
@@ -2,7 +2,7 @@
 
 CWD="$(cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 
-export PROJECT_ROOT="${PROJECT_ROOT:-"$(dirname $CWD)"}"
+export PROJECT_ROOT="${PROJECT_ROOT:-"$(dirname "$CWD")"}"
 export ENV_FILE=${ENV_FILE:-"${PROJECT_ROOT}/.env"}
 
 source "${ENV_FILE}"

--- a/bin/watch-storefront.sh
+++ b/bin/watch-storefront.sh
@@ -5,7 +5,7 @@ CWD="$(cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 export PROJECT_ROOT="${PROJECT_ROOT:-"$(dirname $CWD)"}"
 export ENV_FILE=${ENV_FILE:-"${PROJECT_ROOT}/.env"}
 
-source ${ENV_FILE}
+source "${ENV_FILE}"
 export APP_URL
 export STOREFRONT_PROXY_PORT
 export ESLINT_DISABLE

--- a/bin/watch-storefront.sh
+++ b/bin/watch-storefront.sh
@@ -2,7 +2,7 @@
 
 CWD="$(cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 
-export PROJECT_ROOT="${PROJECT_ROOT:-"$(dirname $CWD)"}"
+export PROJECT_ROOT="${PROJECT_ROOT:-"$(dirname "$CWD")"}"
 export ENV_FILE=${ENV_FILE:-"${PROJECT_ROOT}/.env"}
 
 source "${ENV_FILE}"
@@ -10,5 +10,5 @@ export APP_URL
 export STOREFRONT_PROXY_PORT
 export ESLINT_DISABLE
 
-${CWD}/console theme:dump
+"${CWD}"/console theme:dump
 npm --prefix vendor/shopware/storefront/Resources/app/storefront/ run-script hot-proxy


### PR DESCRIPTION
when having a path like /Users/My Name/Workspace/.env it will become broken and the .env file can't be "sourced"