### PR TITLE
Hide nginx version in response headers

### DIFF
--- a/config/etc/nginx/nginx.conf
+++ b/config/etc/nginx/nginx.conf
@@ -28,6 +28,9 @@ http {
     uwsgi_temp_path /tmp/uwsgi_temp;
     scgi_temp_path /tmp/scgi_temp;
 
+    # Hide nginx version in headers
+    server_tokens off;
+
     # Default server definition
     server {
         listen [::]:8000 default_server;


### PR DESCRIPTION
Currently the active nginx version is exposed in the headers, e.g.: `server: nginx/1.19.0`, allowing possible attackers more targeted attacks on systems running this config.

Adding the config `server_tokens off;` disables the version of nginx without needing any additional module, resulting in slightly better security.