### PR TITLE
Compile theme at the end of build-storefront.sh

### DIFF
--- a/bin/build-storefront.sh
+++ b/bin/build-storefront.sh
@@ -11,3 +11,4 @@ npm --prefix ${STOREFRONT_ROOT}/Resources/app/storefront clean-install
 node ${STOREFRONT_ROOT}/Resources/app/storefront/copy-to-vendor.js
 npm --prefix ${STOREFRONT_ROOT}/Resources/app/storefront run production
 [[ ${CI} ]] || "${CWD}/console" asset:install
+[[ ${CI} ]] || "${CWD}/console" theme:compile


### PR DESCRIPTION
When you build the storefront, you would expect your changes to be visible in the storefront. With this change, that will be possible. It will follow the behavior of the development template: https://github.com/shopware/development/blob/master/dev-ops/storefront/actions/build.sh