### PR TITLE
Fix ineffective whitelisting for custom/plugins/.gitkeep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 custom/*
+!custom/plugins/
+custom/plugins/*
 !custom/plugins/.gitkeep
 !custom/static-plugins/
 


### PR DESCRIPTION
The current ruleset for the custom folder forgets to whitelist the custom/plugins folder, which turns the whitelisting for custom/plugins/.gitkeep ineffective.

This PR fixes that issue.