### PR TITLE
Add support for bundled private composer dependencies via path repo

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,13 @@
     "repositories": [
         {
             "type": "path",
+            "url": "custom/plugins/*/packages/*",
+            "options": {
+                "symlink": true
+            }
+        },
+        {
+            "type": "path",
             "url": "custom/static-plugins/*",
             "options": {
                 "symlink": true


### PR DESCRIPTION
In v6.4.0.0 Shopware will add support for plugins which manage their dependencies via composer:
- https://github.com/shopware/platform/commit/59d90d70f177e204ba606905a80417f60ad5e515
- https://jira.shopware.com/browse/NEXT-1797

Currently with this upcoming change in Shopware v6.4.0.0, there is a need to also support private dependencies which you bundle with the plugin.
This PR enables the usage of private dependencies through a path repo `packages` within each plugin directory.

The plugins directory structure would thus look like this:

```
MyAwesomePlugin
├── packages
│   └── my-private-dependency/
│       ├── composer.json
│       └── src/
│           └── SomeCoolService.php
├── src/
│   └── MyAwesomePlugin.php
└── composer.json
```

and the plugins composer.json would require the private dependency like any other dependency:
```json
"require": {
    "my-vendor-name/my-private-dependency": "^1.2.3",
}
```