### PR TITLE
Fix english version of the Readme a bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ See also: https://www.shopware.com/en/news/shopware-6-versioning-strategy/
 
 See [https://docs.shopware.com/en/shopware-platform-dev-en/getting-started/requirements](https://docs.shopware.com/en/shopware-platform-dev-en/getting-started/requirements)
 
-NPM and Node are only required during the build process and for development. If you don't have javascript customizations, it's not required at all. Because the storefront and admin are pre-build.
+NPM and Node are only required during the build process and for development. If you don't have javascript customizations it's not required at all because the storefront and admin are prebuilt.
 
 If you are using a separate build server, consider having NPM and Node as build-only requirements. Your operating application server doesn't require any of these to run Shopware 6.
 
@@ -237,7 +237,7 @@ The following directories should be shared by all app servers:
 .
 ├── config
 │   ├── jwt # ro - should be written on first deployment
-│   ├── secrets # rw shared - see, if you want to use it: https://symfony.com/blog/new-in-symfony-4-4-encrypted-secrets-management 
+│   ├── secrets # rw shared - For usage refer to: https://symfony.com/blog/new-in-symfony-4-4-encrypted-secrets-management 
 ├── public
 │   ├── bundles # rw shared - Written by `assets:install` / `theme:compile`, can also be initiated by the administration
 │   ├── media # rw shared
@@ -245,12 +245,12 @@ The following directories should be shared by all app servers:
 │   └── thumbnail # rw shared - media thumbnails
 │   └── sitemap # rw shared - generated sitemaps
 ├── var
-│   ├── cache # rw local - contains the containers, which contains additional cache directories (twig, translations, etc)
-│   ├── log # a - append only, can be change in the monlog config
+│   ├── cache # rw local - contains the containers which contain additional cache directories (twig, translations, etc)
+│   ├── log # a - append only, can be changed in the monolog config
 
 ro - Readonly after deployment
 rw shared - read and write access, it should be shared across the app servers
-rw local - locale read and write access
+rw local - local read and write access
 ```
 
-Some of these directories like `public` can also be changed to different flysystem to host the files on s3 for example.
+Some of these directories like `public` can also be changed to a different flysystem to host the files on s3 for example.


### PR DESCRIPTION
There's a few more things like "generated themes by `theme:compile/change`" that'd require to know the exact functionality to fix the wording.

As well as a lot of German capitalization, one included in this PR for reference (- For).