### PR TITLE
Fix symfony 5 minor deprecations

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -27,7 +27,7 @@ if (!class_exists(Application::class)) {
 $envFile = __DIR__ . '/../.env';
 
 if (class_exists(Dotenv::class) && is_readable($envFile) && !is_dir($envFile)) {
-    (new Dotenv(true))->load(__DIR__ . '/../.env');
+    (new Dotenv())->load(__DIR__ . '/../.env');
 }
 
 if (!isset($_SERVER['PROJECT_ROOT'])) {

--- a/public/index.php
+++ b/public/index.php
@@ -61,7 +61,7 @@ if ($debug) {
 
 $trustedProxies = $_SERVER['TRUSTED_PROXIES'] ?? $_ENV['TRUSTED_PROXIES'] ?? false;
 if ($trustedProxies) {
-    Request::setTrustedProxies(explode(',', $trustedProxies), Request::HEADER_X_FORWARDED_ALL ^ Request::HEADER_X_FORWARDED_HOST);
+    Request::setTrustedProxies(explode(',', $trustedProxies), Request::HEADER_X_FORWARDED_FOR | Request::HEADER_X_FORWARDED_PORT | Request::HEADER_X_FORWARDED_PROTO);
 }
 
 $trustedHosts = $_SERVER['TRUSTED_HOSTS'] ?? $_ENV['TRUSTED_HOSTS'] ?? false;

--- a/public/index.php
+++ b/public/index.php
@@ -46,7 +46,7 @@ if (!isset($_SERVER['APP_ENV']) && !isset($_ENV['APP_ENV'])) {
     }
     $envFile = __DIR__ . '/../.env';
     if (file_exists($envFile)) {
-        (new Dotenv(true))->load($envFile);
+        (new Dotenv())->load($envFile);
     }
 }
 

--- a/src/TestBootstrap.php
+++ b/src/TestBootstrap.php
@@ -57,5 +57,5 @@ if (file_exists(TEST_PROJECT_DIR . '/.env.test')) {
     if (!class_exists(Dotenv::class)) {
         throw new RuntimeException('APP_ENV environment variable is not defined. You need to define environment variables for configuration or add "symfony/dotenv" as a Composer dependency to load variables from a .env.test file.');
     }
-    (new Dotenv(true))->load(TEST_PROJECT_DIR . '/.env.test');
+    (new Dotenv())->load(TEST_PROJECT_DIR . '/.env.test');
 }


### PR DESCRIPTION
Minor changes to fix deprecation notices related to symfony v5.x

- Dotenv changed it's constructor arguments in v5 in symfony/symfony#35308
- Request::HEADER_X_FORWARDED_ALL was deprecated in symfony/symfony#38954