### PR TITLE
Add CLI options for simpler CLI based setup

### DIFF
--- a/src/Command/SystemSetupCommand.php
+++ b/src/Command/SystemSetupCommand.php
@@ -42,7 +42,7 @@ class SystemSetupCommand extends Command
             ->addArgument('APP_ENV', InputArgument::OPTIONAL, 'Application environment')
             ->addArgument('APP_URL', InputArgument::OPTIONAL, 'Application URL')
             ->addArgument('BLUE_GREEN_DEPLOYMENT', InputArgument::OPTIONAL, 'Blue green deployment')
-            ->addArgument('DATABASE_URL', InputArgument::OPTIONAL, 'Database URL')
+            ->addArgument('DATABASE_URL', InputArgument::OPTIONAL, 'Database URL mysql://user:password@host:port')
 
         ;
         $this->addOption('force', 'f', InputOption::VALUE_NONE, 'Force setup');

--- a/src/Command/SystemSetupCommand.php
+++ b/src/Command/SystemSetupCommand.php
@@ -76,8 +76,9 @@ class SystemSetupCommand extends Command
 
         if ($input->getOption('cli')) {
        		$env['APP_ENV'] = $input->getArgument('APP_ENV');
-       		$env['APP_URL'] = $input->getArgument('APP_URL');
+       		$env['APP_URL'] = trim($input->getArgument('APP_URL'));
        		$env['BLUE_GREEN_DEPLOYMENT'] = (int) $input->getArgument('BLUE_GREEN_DEPLOYMENT');
+       		$this->generateJwt($input, $io);
        		$key = Key::createNewRandomKey();
        		$env['APP_SECRET'] = $key->saveToAsciiSafeString();
         	$env['INSTANCE_ID'] = $this->generateInstanceId();

--- a/src/Command/SystemSetupCommand.php
+++ b/src/Command/SystemSetupCommand.php
@@ -43,6 +43,7 @@ class SystemSetupCommand extends Command
             ->addArgument('APP_URL', InputArgument::OPTIONAL, 'Application URL')
             ->addArgument('BLUE_GREEN_DEPLOYMENT', InputArgument::OPTIONAL, 'Blue green deployment')
             ->addArgument('DATABASE_URL', InputArgument::OPTIONAL, 'Database URL mysql://user:password@host:port')
+            ->addArgument('DATABASE_NAME', InputArgument::OPTIONAL, 'Database name')
 
         ;
         $this->addOption('force', 'f', InputOption::VALUE_NONE, 'Force setup');
@@ -80,7 +81,8 @@ class SystemSetupCommand extends Command
        		$key = Key::createNewRandomKey();
        		$env['APP_SECRET'] = $key->saveToAsciiSafeString();
         	$env['INSTANCE_ID'] = $this->generateInstanceId();
-        	$env['DATABASE_URL'] = $this->getDsn($input, $io);
+        	$env['DATABASE_URL'] = $this->getDsn($input, $io)."/".$input->getArgument('DATABASE_NAME');
+
 	        $this->createEnvFile($input, $io, $env);
 	        return 0;
 


### PR DESCRIPTION
While trying to setup Shopware via CLI, I couldn't find a non interactive option to automate the install.
Sample use and output:
```
[a19b66ef@cloudhost-505127 shopware]$ APP_URL=http://test.test bin/console system:setup --help
Usage:
  system:setup [options] [--] [<APP_ENV> [<APP_URL> [<BLUE_GREEN_DEPLOYMENT> [<DATABASE_URL>] [<DATABASE_NAME>]]]]

Arguments:
  APP_ENV                                Application environment
  APP_URL                                Application URL
  BLUE_GREEN_DEPLOYMENT                  Blue green deployment
  DATABASE_URL                           Database URL
  DATABASE_NAME                          Database name

Options:
  -f, --force                            Force setup
      --no-check-db-connection           dont check db connection
      --database-url[=DATABASE-URL]      Database dsn
      --generate-jwt-keys                Generate jwt private and public key
      --jwt-passphrase[=JWT-PASSPHRASE]  JWT private key passphrase [default: "shopware"]
      --cli[=CLI]                        CLI based install
  -h, --help                             Display this help message
  -q, --quiet                            Do not output any message
  -V, --version                          Display this application version
      --ansi                             Force ANSI output
      --no-ansi                          Disable ANSI output
  -n, --no-interaction                   Do not ask any interactive question
  -e, --env=ENV                          The Environment name. [default: "prod"]
      --no-debug                         Switches off debug mode.
  -v|vv|vvv, --verbose                   Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug

[a19b66ef@cloudhost-505127 shopware]$ APP_URL=http://test.test bin/console system:setup --cli=true prod http://local.test 1 mysql://a19b66ef_sh:FlecksDirestDosageLaddie@localhost:3306 a19b66ef_sh

Shopware setup process
======================

 This tool will setup your instance.

 ! [NOTE] Checking database credentials                                                                                 

 ! [NOTE] Preparing .env                                                                                                

 /chroot/home/a19b66ef/99b23d4159.nxcli.net/shopware/.env

SHOPWARE_ES_HOSTS="elasticsearch:9200"
SHOPWARE_ES_ENABLED="0"
SHOPWARE_ES_INDEXING_ENABLED="0"
SHOPWARE_ES_INDEX_PREFIX="sw"
SHOPWARE_HTTP_CACHE_ENABLED="1"
SHOPWARE_HTTP_DEFAULT_TTL="7200"
SHOPWARE_CDN_STRATEGY_DEFAULT="id"
BLUE_GREEN_DEPLOYMENT="1"
MAILER_URL="smtp://localhost:25?encryption=&auth_mode="
APP_ENV="prod"
APP_URL="http://local.test"
APP_SECRET="def000002d59421b8350ab19e331092908552dae512286ce43d150ed52525d76cecd9a4dc0411dbcc8c5bd21b8e730bc9788197bb15d19d62872520ccddeacb5001402a3"
INSTANCE_ID="A2diKXgZs6VJg2oDdVPaxQP3WBTjWTlK"
DATABASE_URL="mysql://a19b66ef_sh:FlecksDirestDosageLaddie@localhost:3306/a19b66ef_sh"

 ! [NOTE] Writing into /chroot/home/a19b66ef/99b23d4159.nxcli.net/shopware/.env                                         

[a19b66ef@cloudhost-505127 shopware]$ bin/console system:install --create-database --basic-setup
Prepare installation

Created database `a19b66ef_sh`
Importing base schema.sql


Get collection for identifier: "core"
migrate Migrations
 346/346 [============================] 100%

 ---------- ---------------------- 
  Action     Number of migrations  
 ---------- ---------------------- 
  Migrated   346 out of 346        
 ---------- ---------------------- 

all migrations for identifier: "core" executed
cleared the shopware cache

Get collection for identifier: "core"
migrate Migrations
 346/346 [============================] 100%

 ---------- ---------------------- 
  Action     Number of migrations  
 ---------- ---------------------- 
  Migrated   346 out of 346        
 ---------- ---------------------- 

all migrations for identifier: "core" executed
cleared the shopware cache



Start theme compilation

 ! [NOTE] Took 0,005050 seconds                                                                                         



                                                                                                                        
 [OK] User "admin" successfully created.                                                                                
                                                                                                                        



                                                                                                                        
 [OK] Sales channel has been created successfully.                                                                      
                                                                                                                        

 Access tokens:
+------------+----------------------------+
| Key        | Value                      |
+------------+----------------------------+
| Access key | SWSCYXFLD0UZNLBCTW43SG1BWA |
+------------+----------------------------+

Set "Storefront" as new theme for sales channel "Storefront"
Compiling theme 9855515ad7744230b8536f6de22dfa91 for sales channel Shopware default theme
Set "Storefront" as new theme for sales channel "Headless"
Compiling theme 9855515ad7744230b8536f6de22dfa91 for sales channel Shopware default theme

Copying files for bundle: FrameworkBundle
Copying files for bundle: MonologBundle
Copying files for bundle: SwiftmailerBundle
Copying files for bundle: SensioFrameworkExtraBundle
Copying files for bundle: TwigBundle
Copying files for bundle: EnqueueBundle
Copying files for bundle: EnqueueAdapterBundle
Copying files for bundle: Framework
Copying files for bundle: System
Copying files for bundle: Content
Copying files for bundle: Checkout
Copying files for bundle: Administration
Copying files for bundle: Storefront
Copying files for bundle: Elasticsearch
Copying files for bundle: StaticKernelPluginLoader

                                                                                                                        
 [OK] Successfully copied all bundle files                                                                              
                                                                                                                        



 // Clearing the cache for the prod environment with debug false                                                        

                                                                                                                        
 [OK] Cache for the "prod" environment (debug=false) was successfully cleared.                                          
                                   


```