### PR TITLE
Fix dotenv to use putenv 

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -27,7 +27,9 @@ if (!class_exists(Application::class)) {
 $envFile = __DIR__ . '/../.env';
 
 if (class_exists(Dotenv::class) && is_readable($envFile) && !is_dir($envFile)) {
-    (new Dotenv())->load(__DIR__ . '/../.env');
+    (new Dotenv())
+        ->usePutenv(true)
+        ->load(__DIR__ . '/../.env');
 }
 
 if (!isset($_SERVER['PROJECT_ROOT'])) {

--- a/public/index.php
+++ b/public/index.php
@@ -46,7 +46,9 @@ if (!isset($_SERVER['APP_ENV']) && !isset($_ENV['APP_ENV'])) {
     }
     $envFile = __DIR__ . '/../.env';
     if (file_exists($envFile)) {
-        (new Dotenv())->load($envFile);
+        (new Dotenv())
+            ->usePutenv(true)
+            ->load($envFile);
     }
 }
 

--- a/src/TestBootstrap.php
+++ b/src/TestBootstrap.php
@@ -57,5 +57,7 @@ if (file_exists(TEST_PROJECT_DIR . '/.env.test')) {
     if (!class_exists(Dotenv::class)) {
         throw new RuntimeException('APP_ENV environment variable is not defined. You need to define environment variables for configuration or add "symfony/dotenv" as a Composer dependency to load variables from a .env.test file.');
     }
-    (new Dotenv())->load(TEST_PROJECT_DIR . '/.env.test');
+    (new Dotenv())
+        ->usePutenv(true)
+        ->load(TEST_PROJECT_DIR . '/.env.test');
 }


### PR DESCRIPTION
Hello again,

Sadly in #97 I introduced a regression since Shopware depends a lot on `getenv` calls and not injecting variables.

This PR fixes dotenv to use `putenv` to fix `getenv` calls.