### PR TITLE
Reboot kernel with plugins after before UpdatePostFinishEvent

### DIFF
--- a/src/Command/SystemUpdateFinishCommand.php
+++ b/src/Command/SystemUpdateFinishCommand.php
@@ -57,21 +57,29 @@ class SystemUpdateFinishCommand extends Command
         $output->writeln('Run Post Update');
         $output->writeln('');
 
-        $containerWithoutPlugins = $this->rebootKernelWithoutPlugins();
+        /** @var Kernel $kernel */
+        $kernel = $this->container->get('kernel');
+        $pluginLoader = $kernel->getPluginLoader();
+        
+        try {
+            $containerWithoutPlugins = $this->rebootKernelWithoutPlugins();
 
-        $context = Context::createDefaultContext();
-        $oldVersion = $this->systemConfigService->getString(UpdateController::UPDATE_PREVIOUS_VERSION_KEY);
+            $context = Context::createDefaultContext();
+            $oldVersion = $this->systemConfigService->getString(UpdateController::UPDATE_PREVIOUS_VERSION_KEY);
 
-        $newVersion = $containerWithoutPlugins->getParameter('kernel.shopware_version');
-        if (!\is_string($newVersion)) {
-            throw new \RuntimeException('Container parameter "kernel.shopware_version" needs to be a string');
+            $newVersion = $containerWithoutPlugins->getParameter('kernel.shopware_version');
+            if (!\is_string($newVersion)) {
+                throw new \RuntimeException('Container parameter "kernel.shopware_version" needs to be a string');
+            }
+
+            /** @var EventDispatcherInterface $eventDispatcherWithoutPlugins */
+            $eventDispatcherWithoutPlugins = $this->rebootKernelWithoutPlugins()->get('event_dispatcher');
+            $eventDispatcherWithoutPlugins->dispatch(new UpdatePreFinishEvent($context, $oldVersion, $newVersion));
+
+            $this->runMigrations($output);
+        } finally {
+            $kernel->reboot(null, $pluginLoader);
         }
-
-        /** @var EventDispatcherInterface $eventDispatcherWithoutPlugins */
-        $eventDispatcherWithoutPlugins = $this->rebootKernelWithoutPlugins()->get('event_dispatcher');
-        $eventDispatcherWithoutPlugins->dispatch(new UpdatePreFinishEvent($context, $oldVersion, $newVersion));
-
-        $this->runMigrations($output);
 
         $updateEvent = new UpdatePostFinishEvent($context, $oldVersion, $newVersion);
         $this->eventDispatcher->dispatch($updateEvent);


### PR DESCRIPTION
Currently the event `\Shopware\Core\Framework\Update\Event\UpdatePostFinishEvent` is dispatched when the kernel has no plugins. The subscriber `\Shopware\Storefront\Theme\Subscriber\UpdateSubscriber` then compiles the themes for all storefronts. If a storefront has a custom theme assigned, this requires the presence of the theme plugin, so the process dies here.

I save the plugin loader before the kernel is rebooted without plugins and reboot the kernel again with said plugin loader right before the `\Shopware\Core\Framework\Update\Event\UpdatePostFinishEvent` is dispatched. Now the theme can be loaded, even if it is a plugin.