### PR TITLE
Decouple the application from the global state

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -1,5 +1,5 @@
 #!/usr/bin/env php
-<?php declare(strict_types=1);
+<?php
 
 use Composer\InstalledVersions;
 use Shopware\Core\Framework\Plugin\KernelPluginLoader\DbalKernelPluginLoader;
@@ -8,63 +8,56 @@ use Shopware\Production\HttpKernel;
 use Shopware\Production\Kernel;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\ArgvInput;
-use Symfony\Component\Dotenv\Dotenv;
-use Symfony\Component\ErrorHandler\Debug;
-
-if (\PHP_VERSION_ID < 70400) {
-    echo 'Your cli is running PHP version ' . \PHP_VERSION . ' but Shopware 6 requires at least PHP 7.4.0' . \PHP_EOL;
-    exit(1);
-}
-
-set_time_limit(0);
-
-$classLoader = require __DIR__ . '/../vendor/autoload.php';
-
-if (!class_exists(Application::class)) {
-    throw new RuntimeException('You need to add "symfony/framework-bundle" as a Composer dependency.');
-}
 
 $envFile = __DIR__ . '/../.env';
 
-if (class_exists(Dotenv::class) && is_readable($envFile) && !is_dir($envFile)) {
-    (new Dotenv())->usePutenv()->load($envFile);
+if (!file_exists(__DIR__ . '/../.env')) {
+    $_SERVER['APP_RUNTIME_OPTIONS']['disable_dotenv'] = true;
 }
 
-if (!isset($_SERVER['PROJECT_ROOT'])) {
-    $_SERVER['PROJECT_ROOT'] = dirname(__DIR__);
-}
+require_once __DIR__ . '/../vendor/autoload_runtime.php';
 
-$input = new ArgvInput();
-$env = $input->getParameterOption(['--env', '-e'], $_SERVER['APP_ENV'] ?? 'prod', true);
-$debug = ($_SERVER['APP_DEBUG'] ?? ($env !== 'prod')) && !$input->hasParameterOption('--no-debug', true);
-
-if ($debug) {
-    umask(0000);
-
-    if (class_exists(Debug::class)) {
-        Debug::enable();
+return function (array $context) {
+    if (\PHP_VERSION_ID < 70400) {
+        echo 'Your cli is running PHP version ' . \PHP_VERSION . ' but Shopware 6 requires at least PHP 7.4.0' . \PHP_EOL;
+        exit(1);
     }
-}
 
-$pluginLoader = new StaticKernelPluginLoader($classLoader, null);
+    set_time_limit(0);
 
-$shopwareVersion = InstalledVersions::getVersion('shopware/core') . '@' . InstalledVersions::getReference('shopware/core');
+    $classLoader = require __DIR__ . '/../vendor/autoload.php';
 
-if ($input->getFirstArgument() === 'system:install') {
-    $_SERVER['INSTALL'] = true;
-}
-
-if (trim($_SERVER['DATABASE_URL'] ?? '') === '') {
-    // fake DATABASE_URL
-    $_SERVER['DATABASE_URL'] = Kernel::PLACEHOLDER_DATABASE_URL;
-} else {
-    if (!isset($_SERVER['INSTALL'])) {
-        $pluginLoader = new DbalKernelPluginLoader($classLoader, null, \Shopware\Core\Kernel::getConnection());
+    if (!class_exists(Application::class)) {
+        throw new RuntimeException('You need to add "symfony/framework-bundle" as a Composer dependency.');
     }
-}
 
-$kernel = new HttpKernel($env, $debug, $classLoader);
-$kernel->setPluginLoader($pluginLoader);
+    if (!isset($context['PROJECT_ROOT'])) {
+        $context['PROJECT_ROOT'] = dirname(__DIR__);
+    }
 
-$application = new Application($kernel->getKernel());
-$application->run($input);
+    $input = new ArgvInput();
+    $env = $input->getParameterOption(['--env', '-e'], $context['APP_ENV'] ?? 'prod', true);
+    $debug = ($context['APP_DEBUG'] ?? ($env !== 'prod')) && !$input->hasParameterOption('--no-debug', true);
+
+    $pluginLoader = new StaticKernelPluginLoader($classLoader, null);
+
+    $shopwareVersion = InstalledVersions::getVersion('shopware/core') . '@' . InstalledVersions::getReference('shopware/core');
+
+    if ($input->getFirstArgument() === 'system:install') {
+        $context['INSTALL'] = true;
+    }
+
+    if (trim($context['DATABASE_URL'] ?? '') === '') {
+        // fake DATABASE_URL
+        putenv('DATABASE_URL=' . Kernel::PLACEHOLDER_DATABASE_URL);
+    } else {
+        if (!isset($context['INSTALL'])) {
+            $pluginLoader = new DbalKernelPluginLoader($classLoader, null, \Shopware\Core\Kernel::getConnection());
+        }
+    }
+
+    $kernel = new HttpKernel($env, $debug, $classLoader);
+    $kernel->setPluginLoader($pluginLoader);
+
+    return new Application($kernel->getKernel());
+};

--- a/bin/console
+++ b/bin/console
@@ -49,7 +49,7 @@ return function (array $context) {
 
     if (trim($context['DATABASE_URL'] ?? '') === '') {
         // fake DATABASE_URL
-        putenv('DATABASE_URL=' . Kernel::PLACEHOLDER_DATABASE_URL);
+        $_SERVER['DATABASE_URL'] = Kernel::PLACEHOLDER_DATABASE_URL;
     } else {
         if (!isset($context['INSTALL'])) {
             $pluginLoader = new DbalKernelPluginLoader($classLoader, null, \Shopware\Core\Kernel::getConnection());

--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,8 @@
         "shopware/core": "~v6.4.0",
         "shopware/elasticsearch": "~v6.4.0",
         "shopware/recovery": "~v6.4.0",
-        "shopware/storefront": "~v6.4.0"
+        "shopware/storefront": "~v6.4.0",
+        "symfony/runtime": "^5.3"
     },
     "require-dev": {
         "ext-openssl": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "adaf1be30a8c8530cf797d42f6607c9d",
+    "content-hash": "3b2cbb70ad454df4cc76bce1fe0c0b9a",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -9425,6 +9425,83 @@
             "time": "2021-07-23T15:55:36+00:00"
         },
         {
+            "name": "symfony/runtime",
+            "version": "v5.3.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/runtime.git",
+                "reference": "685a4a5491e25c7f2dd251d8fcca583b427ff290"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/runtime/zipball/685a4a5491e25c7f2dd251d8fcca583b427ff290",
+                "reference": "685a4a5491e25c7f2dd251d8fcca583b427ff290",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0|^2.0",
+                "php": ">=7.2.5",
+                "symfony/polyfill-php80": "^1.15"
+            },
+            "conflict": {
+                "symfony/dotenv": "<5.1"
+            },
+            "require-dev": {
+                "composer/composer": "^1.0.2|^2.0",
+                "symfony/console": "^4.4|^5",
+                "symfony/dotenv": "^5.1",
+                "symfony/http-foundation": "^4.4|^5",
+                "symfony/http-kernel": "^4.4|^5"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Symfony\\Component\\Runtime\\Internal\\ComposerPlugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Runtime\\": "",
+                    "Symfony\\Runtime\\Symfony\\Component\\": "Internal/"
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Enables decoupling PHP applications from global state",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/runtime/tree/v5.3.4"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-06-30T13:49:12+00:00"
+        },
+        {
             "name": "symfony/security-core",
             "version": "v5.3.6",
             "source": {
@@ -13827,5 +13904,5 @@
     "platform-overrides": {
         "php": "7.4.3"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/public/index.php
+++ b/public/index.php
@@ -1,81 +1,87 @@
 <?php declare(strict_types=1);
 
 use Shopware\Production\HttpKernel;
-use Symfony\Component\Dotenv\Dotenv;
-use Symfony\Component\ErrorHandler\Debug;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\TerminableInterface;
 
-if (\PHP_VERSION_ID < 70400) {
-    header('Content-type: text/html; charset=utf-8', true, 503);
+$_SERVER['SCRIPT_FILENAME'] = __FILE__;
 
-    echo '<h2>Error</h2>';
-    echo 'Your server is running PHP version ' . \PHP_VERSION . ' but Shopware 6 requires at least PHP 7.4.0';
-    exit(1);
+require_once __DIR__ . '/../vendor/autoload_runtime.php';
+
+if (!file_exists(__DIR__ . '/../.env')) {
+    $_SERVER['APP_RUNTIME_OPTIONS']['disable_dotenv'] = true;
 }
 
-$classLoader = require __DIR__ . '/../vendor/autoload.php';
+return function (array $context) {
+    if (\PHP_VERSION_ID < 70400) {
+        header('Content-type: text/html; charset=utf-8', true, 503);
 
-if (!file_exists(dirname(__DIR__) . '/install.lock')) {
-    $basePath = 'recovery/install';
-    $baseURL = str_replace(basename(__FILE__), '', $_SERVER['SCRIPT_NAME']);
-    $baseURL = rtrim($baseURL, '/');
-    $installerURL = $baseURL . '/' . $basePath . '/index.php';
-    if (strpos($_SERVER['REQUEST_URI'], $basePath) === false) {
-        header('Location: ' . $installerURL);
+        echo '<h2>Error</h2>';
+        echo 'Your server is running PHP version ' . \PHP_VERSION . ' but Shopware 6 requires at least PHP 7.4.0';
+        exit(1);
+    }
+
+    $classLoader = require __DIR__ . '/../vendor/autoload.php';
+
+    if (!file_exists(dirname(__DIR__) . '/install.lock')) {
+        $basePath = 'recovery/install';
+        $baseURL = str_replace(basename(__FILE__), '', $context['SCRIPT_FILENAME']);
+        $baseURL = rtrim($baseURL, '/');
+        $installerURL = $baseURL . '/' . $basePath . '/index.php';
+        if (strpos($context['REQUEST_URI'], $basePath) === false) {
+            header('Location: ' . $installerURL);
+            exit;
+        }
+    }
+
+    if (is_file(dirname(__DIR__) . '/files/update/update.json') || is_dir(dirname(__DIR__) . '/update-assets')) {
+        header('Content-type: text/html; charset=utf-8', true, 503);
+        header('Status: 503 Service Temporarily Unavailable');
+        header('Retry-After: 1200');
+        if (file_exists(__DIR__ . '/maintenance.html')) {
+            readfile(__DIR__ . '/maintenance.html');
+        } else {
+            readfile(__DIR__ . '/recovery/update/maintenance.html');
+        }
+
         exit;
     }
-}
 
-if (is_file(dirname(__DIR__) . '/files/update/update.json') || is_dir(dirname(__DIR__) . '/update-assets')) {
-    header('Content-type: text/html; charset=utf-8', true, 503);
-    header('Status: 503 Service Temporarily Unavailable');
-    header('Retry-After: 1200');
-    if (file_exists(__DIR__ . '/maintenance.html')) {
-        readfile(__DIR__ . '/maintenance.html');
-    } else {
-        readfile(__DIR__ . '/recovery/update/maintenance.html');
+    $appEnv = $context['APP_ENV'] ?? 'dev';
+    $debug = (bool) ($context['APP_DEBUG'] ?? ($appEnv !== 'prod'));
+
+    $trustedProxies = $context['TRUSTED_PROXIES'] ?? false;
+    if ($trustedProxies) {
+        Request::setTrustedProxies(explode(',', $trustedProxies),
+            Request::HEADER_X_FORWARDED_FOR | Request::HEADER_X_FORWARDED_PORT | Request::HEADER_X_FORWARDED_PROTO);
     }
 
-    return;
-}
-
-// The check is to ensure we don't use .env if APP_ENV is defined
-if (!isset($_SERVER['APP_ENV']) && !isset($_ENV['APP_ENV'])) {
-    if (!class_exists(Dotenv::class)) {
-        throw new \RuntimeException('APP_ENV environment variable is not defined. You need to define environment variables for configuration or add "symfony/dotenv" as a Composer dependency to load variables from a .env file.');
+    $trustedHosts = $context['TRUSTED_HOSTS'] ?? false;
+    if ($trustedHosts) {
+        Request::setTrustedHosts(explode(',', $trustedHosts));
     }
-    $envFile = __DIR__ . '/../.env';
-    if (file_exists($envFile)) {
-        (new Dotenv())
-            ->usePutenv(true)
-            ->load($envFile);
-    }
-}
 
-$appEnv = $_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? 'dev';
-$debug = (bool) ($_SERVER['APP_DEBUG'] ?? $_ENV['APP_DEBUG'] ?? ($appEnv !== 'prod'));
+    $shopwareHttpKernel = new HttpKernel($appEnv, $debug, $classLoader);
 
-if ($debug) {
-    umask(0000);
+    return new class ($shopwareHttpKernel) implements HttpKernelInterface, TerminableInterface
+    {
+        private HttpKernel $httpKernel;
 
-    Debug::enable();
-}
+        public function __construct(HttpKernel $httpKernel)
+        {
+            $this->httpKernel = $httpKernel;
+        }
 
-$trustedProxies = $_SERVER['TRUSTED_PROXIES'] ?? $_ENV['TRUSTED_PROXIES'] ?? false;
-if ($trustedProxies) {
-    Request::setTrustedProxies(explode(',', $trustedProxies), Request::HEADER_X_FORWARDED_FOR | Request::HEADER_X_FORWARDED_PORT | Request::HEADER_X_FORWARDED_PROTO);
-}
+        public function handle(Request $request, int $type = self::MASTER_REQUEST, bool $catch = true)
+        {
+            return $this->httpKernel->handle($request, $type, $catch)->getResponse();
+        }
 
-$trustedHosts = $_SERVER['TRUSTED_HOSTS'] ?? $_ENV['TRUSTED_HOSTS'] ?? false;
-if ($trustedHosts) {
-    Request::setTrustedHosts(explode(',', $trustedHosts));
-}
-
-$request = Request::createFromGlobals();
-
-$kernel = new HttpKernel($appEnv, $debug, $classLoader);
-$result = $kernel->handle($request);
-
-$result->getResponse()->send();
-
-$kernel->terminate($result->getRequest(), $result->getResponse());
+        public function terminate(Request $request, Response $response)
+        {
+            $this->httpKernel->terminate($request, $response);
+        }
+    };
+};

--- a/public/index.php
+++ b/public/index.php
@@ -54,8 +54,10 @@ return function (array $context) {
 
     $trustedProxies = $context['TRUSTED_PROXIES'] ?? false;
     if ($trustedProxies) {
-        Request::setTrustedProxies(explode(',', $trustedProxies),
-            Request::HEADER_X_FORWARDED_FOR | Request::HEADER_X_FORWARDED_PORT | Request::HEADER_X_FORWARDED_PROTO);
+        Request::setTrustedProxies(
+            explode(',', $trustedProxies),
+            Request::HEADER_X_FORWARDED_FOR | Request::HEADER_X_FORWARDED_PORT | Request::HEADER_X_FORWARDED_PROTO
+        );
     }
 
     $trustedHosts = $context['TRUSTED_HOSTS'] ?? false;
@@ -65,8 +67,7 @@ return function (array $context) {
 
     $shopwareHttpKernel = new HttpKernel($appEnv, $debug, $classLoader);
 
-    return new class ($shopwareHttpKernel) implements HttpKernelInterface, TerminableInterface
-    {
+    return new class($shopwareHttpKernel) implements HttpKernelInterface, TerminableInterface {
         private HttpKernel $httpKernel;
 
         public function __construct(HttpKernel $httpKernel)
@@ -79,7 +80,7 @@ return function (array $context) {
             return $this->httpKernel->handle($request, $type, $catch)->getResponse();
         }
 
-        public function terminate(Request $request, Response $response)
+        public function terminate(Request $request, Response $response): void
         {
             $this->httpKernel->terminate($request, $response);
         }


### PR DESCRIPTION
This will decouple the application from the global state of its surrounding infrastructure using the [Symfony Runtime Component](https://symfony.com/doc/current/components/runtime.html). In his talk at Symfony World 2021 Tobias Nyholm made some compelling arguments for this change.