### PR TITLE
Added system:prepare script to the post install and post update scrip…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,12 +21,14 @@
         "post-install-cmd": [
             "@composer install --working-dir vendor/shopware/recovery --no-interaction --no-scripts",
             "@composer install --working-dir=vendor/shopware/recovery/Common --no-interaction --optimize-autoloader --no-suggest",
-            "[ ! -f install.lock ] || $PHP_BINARY bin/console system:update:finish"
+            "[ ! -f vendor/autoload.php ] || $PHP_BINARY bin/console system:update:prepare",
+            "[ ! -f vendor/autoload.php ] || $PHP_BINARY bin/console system:update:finish"
         ],
         "post-update-cmd": [
             "@composer install --working-dir vendor/shopware/recovery --no-interaction --no-scripts",
             "@composer install --working-dir=vendor/shopware/recovery/Common --no-interaction --optimize-autoloader --no-suggest",
-            "[ ! -f install.lock ] || $PHP_BINARY bin/console system:update:finish"
+            "[ ! -f vendor/autoload.php ] || $PHP_BINARY bin/console system:update:prepare",
+            "[ ! -f vendor/autoload.php ] || $PHP_BINARY bin/console system:update:finish"
         ]
     },
     "autoload": {


### PR DESCRIPTION
There is two possible issues with the composer scripts when installing an existing Shopware site in a CI such as bitbucket pipelines.

The first issue is that "bin/console system:update:prepare" on pre-install might not run. This is because the vendor directory might not exist or possibly some migration scripts not be added as the package isn't updated.

The second issue is that "bin/console system:update:finish" relied on a install.lock file which wouldn't be there after an install of Shopware so I changed this to rely on vendor/autoload.php file instead.