### PR TITLE
fix: Use an empty string as fallback password to not fail in rawurlencode

### DIFF
--- a/src/Command/SystemSetupCommand.php
+++ b/src/Command/SystemSetupCommand.php
@@ -177,7 +177,7 @@ class SystemSetupCommand extends Command
         };
 
         $dbUser = $io->ask('Database user', 'app', $emptyValidation);
-        $dbPass = $io->askHidden('Database password');
+        $dbPass = $io->askHidden('Database password') ?: '';
         $dbHost = $io->ask('Database host', 'localhost', $emptyValidation);
         $dbPort = $io->ask('Database port', '3306', $emptyValidation);
         $dbName = $io->ask('Database name', 'shopware', $emptyValidation);


### PR DESCRIPTION
Otherwise the `rawurlencode` will fail since it expects a string.

Apparently it is not possible to specify a default value for the `SymfonyStyle::askHidden` method.