### PR TITLE
build-storefront.sh: Stop on Errors

### DIFF
--- a/bin/build-storefront.sh
+++ b/bin/build-storefront.sh
@@ -2,6 +2,8 @@
 
 CWD="$(cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 
+set -e
+
 export PROJECT_ROOT="${PROJECT_ROOT:-"$(dirname "$CWD")"}"
 STOREFRONT_ROOT="${STOREFRONT_ROOT:-"${PROJECT_ROOT}/vendor/shopware/storefront"}"
 


### PR DESCRIPTION
The script should stop on errors, just like build-administration.sh does