### PR TITLE
Stop if JQ is not installed

### DIFF
--- a/bin/build-storefront.sh
+++ b/bin/build-storefront.sh
@@ -40,7 +40,8 @@ if [[ $(command -v jq) ]]; then
     done
     cd "$OLDPWD" || exit
 else
-    echo "Cannot check extensions for required npm installations as jq is not installed"
+    echo "FATAL: Cannot check extensions for required npm installations as jq is not installed"
+    exit
 fi
 
 npm --prefix "${STOREFRONT_ROOT}"/Resources/app/storefront clean-install


### PR DESCRIPTION
Running the build without JQ will only lead to more problems, so it is better to fail early