### PR TITLE
Add auth.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+/auth.json
+
 custom/*
 !custom/plugins/.gitkeep
 !custom/static-plugins/


### PR DESCRIPTION
> Stelle sicher, dass sich die Datei auth.json in .gitignore befindet, um zu verhindern, dass Zugangsdaten in den Git-Verlauf gelangen

Translation to englisch: Make sure, that the file auth.json is in your gitignore to avoid that credentials are part of your git history