### PR TITLE
Indent yml files only with 2 spaces

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,5 +13,8 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
+[*.yml]
+indent_size = 2
+
 [*.md]
 trim_trailing_whitespace = false


### PR DESCRIPTION
You indent your yml files with only 2 spaces, as I do, so let's tell our IDEs what we want :-)