### PR TITLE
fix: Fixed looking up for node_modules directory

### DIFF
--- a/bin/build-administration.sh
+++ b/bin/build-administration.sh
@@ -28,7 +28,7 @@ if [[ $(command -v jq) ]]; then
         path=$(dirname "$srcPath")
         name=$(echo "$config" | jq -r '.technicalName' )
 
-        if [[ -f "$path/package.json" && ! -f "$path/node_modules" && $name != "administration" ]]; then
+        if [[ -f "$path/package.json" && ! -d "$path/node_modules" && $name != "administration" ]]; then
             echo "=> Installing npm dependencies for ${name}"
 
             if [[ -f "$path/package-lock.json" ]]; then

--- a/bin/build-storefront.sh
+++ b/bin/build-storefront.sh
@@ -29,7 +29,7 @@ if [[ $(command -v jq) ]]; then
         path=$(dirname "$srcPath")
         name=$(echo "$config" | jq -r '.technicalName' )
 
-        if [[ -f "$path/package.json" && ! -f "$path/node_modules" && $name != "storefront" ]]; then
+        if [[ -f "$path/package.json" && ! -d "$path/node_modules" && $name != "storefront" ]]; then
             echo "=> Installing npm dependencies for ${name}"
 
             if [[ -f "$path/package-lock.json" ]]; then


### PR DESCRIPTION
## Changes

This PR will fix looking up for the `node_modules` directory in the `bin/build-(administration|storefront).sh`.

## Rationale

Since the `node_modules` directory is a directory, you need the `-d` operator to check its existence.

## Related Issues

* #147