### PR TITLE
Avoid custom/plugins dir is ignored during new project initialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,7 @@
 /auth.json
 
-custom/*
+custom/plugins/*
 !custom/plugins/.gitkeep
-!custom/static-plugins/
 
 /vendor/
 /bin/vendor/


### PR DESCRIPTION
This fix solved the following issue: as a developer, I start new shopware based projects with the following behavior:

How to reproduce:

1. `git clone git@github.com:shopware/production.git my-new-shopware-project`
2. `cd my-new-shopware-project && rm -rf .git` # because I don't want to keep the whole shopware git history, branches, and so on
3. `git init`
4. `git add custom`
5. `git status`
```
On branch main

No commits yet

Changes to be committed:
  (use "git rm --cached <file>..." to unstage)
	new file:   custom/static-plugins/.gitkeep
```
The issue here is that the dir `custom/plugins` and his `.gitkeep` are ignored. As consequence other tasks e.g. installing new plugins from the admin panel will fail.