### PR TITLE
Fix bitbucket pipeline usage of build-storefront.sh and build-administration

### DIFF
--- a/bin/build-administration.sh
+++ b/bin/build-administration.sh
@@ -11,7 +11,10 @@ BIN_TOOL="${CWD}/console"
 
 if [[ ${CI-""} ]]; then
     BIN_TOOL="${CWD}/ci"
-    chmod +x "$BIN_TOOL"
+
+    if [[ ! -x "$BIN_TOOL" ]]; then
+        chmod +x "$BIN_TOOL"
+    fi
 fi
 
 # build admin

--- a/bin/build-storefront.sh
+++ b/bin/build-storefront.sh
@@ -11,7 +11,10 @@ BIN_TOOL="${CWD}/console"
 
 if [[ ${CI-""} ]]; then
     BIN_TOOL="${CWD}/ci"
-    chmod +x "$BIN_TOOL"
+
+    if [[ ! -x "$BIN_TOOL" ]]; then
+        chmod +x "$BIN_TOOL"
+    fi
 fi
 
 # build storefront


### PR DESCRIPTION
Bitbucket pipeline for security reasons does not like chmod +x. I had this change a while in my projects but I think it won't hurt when we just add it here as well