### PR TITLE
align asset command to avoid confusion

### DIFF
--- a/bin/build-administration.sh
+++ b/bin/build-administration.sh
@@ -47,5 +47,5 @@ else
 fi
 
 (cd "${ADMIN_ROOT}"/Resources/app/administration && npm clean-install && npm run build)
-[[ ${SHOPWARE_SKIP_ASSET_COPY-""} ]] ||"${BIN_TOOL}" asset:install
+[[ ${SHOPWARE_SKIP_ASSET_COPY-""} ]] ||"${BIN_TOOL}" assets:install
 

--- a/bin/build-storefront.sh
+++ b/bin/build-storefront.sh
@@ -50,5 +50,5 @@ fi
 npm --prefix "${STOREFRONT_ROOT}"/Resources/app/storefront clean-install
 node "${STOREFRONT_ROOT}"/Resources/app/storefront/copy-to-vendor.js
 npm --prefix "${STOREFRONT_ROOT}"/Resources/app/storefront run production
-[[ ${SHOPWARE_SKIP_ASSET_COPY-""} ]] ||"${BIN_TOOL}" asset:install
+[[ ${SHOPWARE_SKIP_ASSET_COPY-""} ]] ||"${BIN_TOOL}" assets:install
 [[ ${SHOPWARE_SKIP_THEME_COMPILE-""} ]] || "${BIN_TOOL}" theme:compile


### PR DESCRIPTION
The command `asset:install` works because symfony translates this to `assets:install`. When searching everywhere for `asset:install` there are no results except for those in build scripts. As it has no added value to shorten the command in a shell, it is more clear to write the full command.