### PR TITLE
ignore install.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,8 @@ custom/*
 
 .envrc
 
+/install.lock
+
 /var/*
 !/var/log/.gitkeep
 !/var/cache/.gitkeep


### PR DESCRIPTION
Currently the `install.lock` file might get committed in projects, based on this production template. Generated files (especially instance specific files) do not belong in git.

This PR adds the `install.lock` file to `.gitignore`.