### PR TITLE
nginx: fix http cache and use gzip

### DIFF
--- a/config/etc/nginx/nginx.conf
+++ b/config/etc/nginx/nginx.conf
@@ -21,6 +21,9 @@ http {
 
     keepalive_timeout 65;
 
+    gzip on;
+    gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript application/javascript application/vnd.api+json;
+
     # Write temporary files to /tmp so they can be created as a non-privileged user
     client_body_temp_path /tmp/client_temp;
     proxy_temp_path /tmp/proxy_temp_path;
@@ -46,7 +49,7 @@ http {
         location / {
             # First attempt to serve request as file, then
             # as directory, then fall back to index.php
-            try_files $uri $uri/ /index.php?q=$uri&$args;
+            try_files $uri /index.php$is_args$args;
         }
 
         # Redirect server error pages to the static page /50x.html
@@ -74,7 +77,7 @@ http {
         location ~* \.(jpg|jpeg|gif|png|css|js|ico|xml)$ {
             expires 5d;
 
-            try_files $uri $uri/ /index.php?q=$uri&$args;
+            try_files $uri /index.php$is_args$args;
         }
 
         # Deny access to . files, for security


### PR DESCRIPTION
Remove unnecessary query parameter “q”, otherwise HTTP cache warm up does not work with nginx because query parameters are part of the cache key. Add GZIP compression for text files (CSS, JS,...) to improve performance.