### PR TITLE
Log bootstrap errors with BufferingLogger

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -3,7 +3,9 @@
 use Shopware\Core\HttpKernel;
 use Shopware\Core\Installer\InstallerKernel;
 use Symfony\Component\Dotenv\Dotenv;
+use Symfony\Component\ErrorHandler\BufferingLogger;
 use Symfony\Component\ErrorHandler\Debug;
+use Symfony\Component\ErrorHandler\ErrorHandler;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -58,6 +60,8 @@ if ($debug) {
     umask(0000);
 
     Debug::enable();
+} else {
+    ErrorHandler::register(new ErrorHandler(new BufferingLogger(), false));
 }
 
 $trustedProxies = $_SERVER['TRUSTED_PROXIES'] ?? $_ENV['TRUSTED_PROXIES'] ?? false;


### PR DESCRIPTION
With `APP_DEBUG=0` (which is the default in the `prod` environment), if an exception occurs in the initial part of request processing (for example when the `\Shopware\Storefront\Framework\Routing\Exception\SalesChannelMappingException` thrown in the `\Shopware\Storefront\Framework\Routing\RequestTransformer::transform()` method) nothing is logged. The developer will see a 500 error page without any clue about the problem. 

**This is the kind of thing that wastes a lot of developers time**.

This happens because in the very initial part of the request processing the `\Symfony\Component\ErrorHandler\ErrorHandler` is not configured with any logger. It will then be configured by the Symfony kernel boot with Monolog but this happens after initial request processing exceptions are eventually thrown.

See also [this issue](https://github.com/symfony/symfony/issues/35575) which is somehow related to this.