### PR TITLE
chore: preset allow-plugins for php-http/discovery

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,7 @@
     "prefer-stable": true,
     "config": {
         "allow-plugins": {
+            "php-http/discovery": false,
             "symfony/flex": true,
             "symfony/runtime": true
         },


### PR DESCRIPTION
### Problem

A fresh `composer create-project shopware/production` interrupts the install with a prompt:

```
php-http/discovery contains a Composer plugin which is currently not in your allow-plugins config.
Do you trust "php-http/discovery" to execute code and wish to enable it now? (writes "allow-plugins" to composer.json) [y,n,d,?]
```

This is not an optional dependency the user opted into — it arrives transitively through Shopware itself.

On a released 6.7.12.1 install:

```
shopware/core                     requires symfony/mcp-bundle (~0.9.0)
symfony/mcp-bundle                requires mcp/sdk (^0.5)
mcp/sdk                           requires php-http/discovery (^1.20)
opensearch-project/opensearch-php requires php-http/discovery (^1.20)
```

And unchanged on current `trunk` (6.7.x-dev), at newer constraints:

```
shopware/platform 6.7.x-dev             requires symfony/mcp-bundle (~0.10.0)
symfony/mcp-bundle v0.10.0              requires mcp/sdk (^0.6)
mcp/sdk v0.6.0                          requires php-http/discovery (^1.20)
opensearch-project/opensearch-php 2.6.0 requires php-http/discovery (^1.20)
```

So every new project hits this prompt, and users are asked to make a trust decision about a package they never chose and most likely have never heard of.

### Proposed change

Preset the entry in the template's `config.allow-plugins`:

```json
"allow-plugins": {
    "php-http/discovery": false,
    "symfony/flex": true,
    "symfony/runtime": true
}
```

### Why `false` rather than `true`

This mirrors [shopware/shopware](https://github.com/shopware/shopware/blob/trunk/composer.json), whose `composer.json` already carries `"php-http/discovery": false` in `allow-plugins`. The production template simply never received the same line, leaving the two inconsistent.

The plugin exists to inject a concrete PSR-18 client when a project has none. Shopware hard-requires `symfony/http-client`, so there is nothing for it to do, and disabling it keeps an install-time plugin from modifying the dependency graph.

**Verified:** a 6.7.12.1 project created via `composer create-project shopware/production`, answering `n` at the prompt so `"php-http/discovery": false` was in effect for the initial resolve. Both consumers of the package (`mcp/sdk` via `symfony/mcp-bundle`, and `opensearch-project/opensearch-php`) were in the graph. Resolution completed with no unsatisfied `psr/http-client-implementation`, and `bin/console es:index` runs successfully against OpenSearch afterwards.

### Result

`composer create-project shopware/production` completes without an interactive prompt, and the template matches core's existing configuration.

---

## Status

- [x] Dependency chain verified on both a released 6.7.12.1 install and current `trunk` (6.7.x-dev). Present in both; constraints differ only in version.
- [x] Confirmed `shopware/template` `trunk` still had only `symfony/flex` + `symfony/runtime` in `allow-plugins` (checked against fresh clone of `c77f2a3`).
- [x] Branch pushed to fork as commit `158fd3d`, authored `Benny Poensgen <benjamin@poensgen.de>`.
- [ ] PR opened — verify base repo is `shopware/template` and base branch is `trunk` on the compare form.
- [ ] Shopware CLA signed (bot will comment on the PR).